### PR TITLE
Fix a typo "Working Directory" instead of "Index"

### DIFF
--- a/book/07-git-tools/sections/reset.asc
+++ b/book/07-git-tools/sections/reset.asc
@@ -228,7 +228,7 @@ We would just run something like `git reset eb43bf file.txt`.
 
 image::images/reset-path3.png[]
 
-This effectively does the same thing as if we had reverted the content of the file to *v1* in the Working Directory, ran `git add` on it, then reverted it back to *v3* again (without actually going through all those steps).
+This effectively does the same thing as if we had reverted the content of the file to *v1* in the Index, ran `git add` on it, then reverted it back to *v3* again (without actually going through all those steps).
 If we run `git commit` now, it will record a change that reverts that file back to *v1*, even though we never actually had it in our Working Directory again.
 
 It's also interesting to note that like `git add`, the `reset` command will accept a `--patch` option to unstage content on a hunk-by-hunk basis.


### PR DESCRIPTION
git-reset with path effect the Index, not Working Directory